### PR TITLE
Build with node 20, bump minimum to 18

### DIFF
--- a/.github/workflows/build-pullrequest.yml
+++ b/.github/workflows/build-pullrequest.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     ]
   },
   "engines": {
-    "node": ">=16.14"
+    "node": ">=18.0"
   },
   "description": "Website for r/JapanFinance wiki"
 }


### PR DESCRIPTION
In preparation of upgrading to Docusaurus v3, bump the declared minimum to 18. Also bump the version we build with to the latest LTS: 20.